### PR TITLE
[HMA-4680] Set Button Padding after updating button

### DIFF
--- a/Sources/UIComponents/Molecules/StatusView.swift
+++ b/Sources/UIComponents/Molecules/StatusView.swift
@@ -121,8 +121,6 @@ extension Components.Molecules {
             if let model = model,
                 model.buttonModel != nil {
                 button = UIButton.styled(style: .secondary)
-                button!.translatesAutoresizingMaskIntoConstraints = false
-                button!.contentEdgeInsets = UIEdgeInsets(top: 0, left: 0, bottom: .spacer12, right: 0)
                 components.append(button!)
             }
             addSubview(stackView)
@@ -192,6 +190,7 @@ extension Components.Molecules {
                     accessibilityIdentifier: buttonModel.accessibilityIdentifier)
                 )
                 button.componentAction(block: buttonModel.actionBlock)
+                button.contentEdgeInsets = UIEdgeInsets(top: 0, left: 0, bottom: .spacer12, right: 0)
             }
         }
     }


### PR DESCRIPTION
From QA feedback on HMA-4680.

The custom button padding set up in a StatusView was being overwritten by the `button.update(...` logic, so I have moved the padding to be set after `button.update(...` is called