### PR TITLE
[HMA-4671] Added actions to HeadlineCardView

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- Added the ability to add an action to `HeadlineCardView`. When `HeadlineCardView` has an action, the whole card is tappable, a chevron is displayed, and the action is called when the user taps the card.
 
 ## [5.8.2] - 2021-07-22Z
 ### Fixed

--- a/CompanionApp/CompanionApp.xcodeproj/project.pbxproj
+++ b/CompanionApp/CompanionApp.xcodeproj/project.pbxproj
@@ -444,7 +444,7 @@
 			repositoryURL = "https://github.com/hmrc/ios-components.git";
 			requirement = {
 				kind = revision;
-				revision = 266ccdec73455e4bb21227fd6aa5c2b3b826031f;
+				revision = e036544074b301064a901251285311f538156267;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/CompanionApp/CompanionApp.xcodeproj/project.pbxproj
+++ b/CompanionApp/CompanionApp.xcodeproj/project.pbxproj
@@ -443,8 +443,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/hmrc/ios-components.git";
 			requirement = {
-				kind = exactVersion;
-				version = 5.8.1;
+				kind = revision;
+				revision = 266ccdec73455e4bb21227fd6aa5c2b3b826031f;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/CompanionApp/CompanionApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/CompanionApp/CompanionApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,7 +6,7 @@
         "repositoryURL": "https://github.com/hmrc/ios-components.git",
         "state": {
           "branch": null,
-          "revision": "266ccdec73455e4bb21227fd6aa5c2b3b826031f",
+          "revision": "e036544074b301064a901251285311f538156267",
           "version": null
         }
       },

--- a/CompanionApp/CompanionApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/CompanionApp/CompanionApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/hmrc/ios-components.git",
         "state": {
           "branch": null,
-          "revision": "516292d8775702304c05b14cfd4fc7e684c6f2a7",
-          "version": "5.6.1"
+          "revision": "266ccdec73455e4bb21227fd6aa5c2b3b826031f",
+          "version": null
         }
       },
       {

--- a/CompanionApp/CompanionApp/Models/ExamplableOrganisms.swift
+++ b/CompanionApp/CompanionApp/Models/ExamplableOrganisms.swift
@@ -36,7 +36,8 @@ extension Components.Organisms.HeadlineCardView: Examplable {
         let modelWithBody = Model(
             title: "Your PAYE income tax estimate",
             headline: "£12,345",
-            views: [UILabel.styled(style: .body, string: "This is the income tax we think you will have paid by the end of this tax year.")])
+            views: [UILabel.styled(style: .body, string: "This is the income tax we think you will have paid by the end of this tax year.")]
+        )
 
         let modelWithLongBody = Model(
             title: ExampleText.LoremIpsum.longer.rawValue,
@@ -114,9 +115,18 @@ extension Components.Organisms.HeadlineCardView: Examplable {
                 UIButton.styled(style: .primary(true), string: "Claim your refund")
             ]
         )
+        let viewWithAction = View(model: modelWithBody)
+        viewWithAction.action = {
+            let controller = UIAlertController(title: "Tapped", message: "Button was tapped", preferredStyle: .alert)
+            controller.addAction(UIAlertAction(title: "OK", style: .default, handler: { (_) in
+                controller.dismiss(animated: true, completion: nil)
+            }))
+            UIApplication.shared.delegate?.window??.rootViewController?
+                .present(controller, animated: true, completion: nil)
+        }
         return [
             View(model: modelP800),
-            View(model: modelWithBody),
+            viewWithAction,
             View(model: modelWithLongBody),
             View(model: modelWithBodyAndPrimaryButton),
             View(model: modelWithBodyAndSecondaryButton),

--- a/Sources/UIComponents/Organisms/HeadlineCardView/HeadlineCardView.swift
+++ b/Sources/UIComponents/Organisms/HeadlineCardView/HeadlineCardView.swift
@@ -184,7 +184,7 @@ extension Components.Organisms {
                 make.centerY.equalTo(snp.centerY)
             }
             if let button = button as? TransparentButton {
-                button.config = TransparentButton.StateConfig(
+                button.config = .init(
                     normalColour: .clear,
                     highlightColour: UIColor.Semantic.secondaryButtonHighlightedBackground,
                     disabledColour: .clear


### PR DESCRIPTION
# 📝 Description

Added the ability to add an action to `HeadlineCardView`. When `HeadlineCardView` has an action, the whole card is tappable, a chevron is displayed, and the action is called when the user taps the card.