### PR TITLE
[HMA-4671] Move Disclosure Logic to CardView

### DIFF
--- a/CompanionApp/CompanionApp.xcodeproj/project.pbxproj
+++ b/CompanionApp/CompanionApp.xcodeproj/project.pbxproj
@@ -443,8 +443,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/hmrc/ios-components.git";
 			requirement = {
-				kind = exactVersion;
-				version = 5.9.0;
+				kind = revision;
+				revision = 4839af268ccbba34be22054412ad35979397c2c0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/CompanionApp/CompanionApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/CompanionApp/CompanionApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/hmrc/ios-components.git",
         "state": {
           "branch": null,
-          "revision": "8d9d2228b7bd7b4fc4e1e07fa053512d21d3ad94",
-          "version": "5.9.0"
+          "revision": "4839af268ccbba34be22054412ad35979397c2c0",
+          "version": null
         }
       },
       {

--- a/CompanionApp/CompanionApp/Models/ExamplableOrganisms.swift
+++ b/CompanionApp/CompanionApp/Models/ExamplableOrganisms.swift
@@ -116,7 +116,7 @@ extension Components.Organisms.HeadlineCardView: Examplable {
             ]
         )
         let viewWithAction = View(model: modelWithBody)
-        viewWithAction.action = {
+        viewWithAction.disclosureAction = {
             let controller = UIAlertController(title: "Tapped", message: "Button was tapped", preferredStyle: .alert)
             controller.addAction(UIAlertAction(title: "OK", style: .default, handler: { (_) in
                 controller.dismiss(animated: true, completion: nil)
@@ -496,7 +496,6 @@ extension Components.Organisms.InformationMessageCard: Examplable {
                     bodyContent: nil
             )
         )
-
         return [
             example1,
             example2,

--- a/Sources/UIComponents/Organisms/HeadlineCardView/HeadlineCardView.swift
+++ b/Sources/UIComponents/Organisms/HeadlineCardView/HeadlineCardView.swift
@@ -133,27 +133,6 @@ extension Components.Organisms {
         // MARK: - Views & Outlets
 
         public let titleHeadlineComponent = TitleHeadlineView()
-        public private(set)var button: UIButton = TransparentButton()
-        public private(set)var disclosureImageView = UIImageView(
-            image: UIImage(
-                named: "ChevronRight",
-                in: Bundle.resource,
-                compatibleWith: nil
-            )
-        )
-        public var action: VoidHandler? {
-            didSet {
-                button.isEnabled = action != nil
-                disclosureImageView.tintColor = action != nil ? UIColor.Semantic.darkText : .clear
-                let chevronWidth: CGFloat = action != nil ? .spacer24 : 0
-                disclosureImageView.snp.updateConstraints { make in
-                    make.width.equalTo(chevronWidth)
-                }
-                adjust([.right], margin: .spacer16 + chevronWidth)
-                stackView.isLayoutMarginsRelativeArrangement = true
-                updateAccessibility()
-            }
-        }
 
         // MARK: - Initialisation
 
@@ -172,47 +151,13 @@ extension Components.Organisms {
         override open func commonInit() {
             super.commonInit()
             self.accessibilityIdentifier = "HeadlineCardView"
-            addSubview(button)
-            addSubview(disclosureImageView)
-            button.snp.makeConstraints { make in
-                make.edges.equalTo(snp.edges)
-            }
-            disclosureImageView.snp.makeConstraints { (make) in
-                make.height.equalTo(CGFloat.spacer24)
-                make.width.equalTo(CGFloat.spacer24)
-                make.right.equalTo(snp.right).inset(CGFloat.spacer16)
-                make.centerY.equalTo(snp.centerY)
-            }
-            if let button = button as? TransparentButton {
-                button.config = .init(
-                    normalColour: .clear,
-                    highlightColour: UIColor.Semantic.secondaryButtonHighlightedBackground,
-                    disabledColour: .clear
-                )
-                button.action = { [weak self] in
-                    self?.action?()
-                }
-            }
-            action = nil
         }
 
         public func updateUI(for model: Model) {
             titleHeadlineComponent.updateUI(for: model)
             setComponents([titleHeadlineComponent] + model.views)
-            button.accessibilityLabel = model.buttonAccessibilityLabel
-            button.accessibilityHint = model.buttonAccessibilityHint
-            updateAccessibility()
-        }
-
-        public func updateAccessibility() {
-            if action != nil {
-                accessibilityElements = [
-                    components,
-                    button
-                ]
-            } else {
-                accessibilityElements = components
-            }
+            disclosureButton.accessibilityLabel = model.buttonAccessibilityLabel
+            disclosureButton.accessibilityHint = model.buttonAccessibilityHint
         }
 
         @discardableResult public func removePadding(onViews views: [UIView]) -> Self {


### PR DESCRIPTION
# 📝 Description
  
As discussed with @paulb00th  & @jemmaSlater, I've moved the disclosure logic to be in the CardView - so that any existing/future CardView that needs a chevron & action already has it out of the box.
