### PR TITLE
[HMA-4966] Fixed bug with SwitchRowView action not being called

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+- Fixed issue with `SwitchRowView` on newer devices.
 
 ## [5.9.3] - 2021-09-02Z
 ### Fixed

--- a/Sources/UIComponents/Molecules/SwitchRowView.swift
+++ b/Sources/UIComponents/Molecules/SwitchRowView.swift
@@ -24,16 +24,9 @@ extension Components.Molecules {
         // MARK: - Views
         public private(set)var switchView: UISwitch = .build {
             $0.onTintColor = UIColor.Semantic.switchTint
-
             $0.layer.borderWidth = 1.0
             $0.layer.cornerRadius = 16.0
             $0.layer.borderColor = UIColor.Named.grey2.raw.cgColor
-
-            $0.addTarget(
-                self,
-                action: #selector(switchChanged(switchView:)),
-                for: .valueChanged
-            )
         }
         public private(set)var titleAndBodyView = BoldTitleBodyView(title: "Some Text", body: "Some Body")
 
@@ -80,6 +73,11 @@ extension Components.Molecules {
 
         override open func commonInit() {
             super.commonInit()
+            switchView.addTarget(
+                self,
+                action: #selector(switchChanged(switchView:)),
+                for: .valueChanged
+            )
             titleAndBodyView.bodyLabel.setAppearance(for: .info)
             self.accessibilityElements = [titleAndBodyView.titleLabel!, titleAndBodyView.bodyLabel!, switchView]
         }


### PR DESCRIPTION
# 📝 Description
  
Moved `switch.addTarget` logic to the common init to resolve issues on newer devices where the target is not called when the switch changes value.
