### PR TITLE
[5.10.2] CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- You can now pass a custom icon size to `StatusView` & `StatusCardView` for icons that are not 100 x 100 
 
 ## [5.10.1] - 2021-10-13Z
 ### Changed


### PR DESCRIPTION
# 📝 Description
  
 Release notes that were omitted from [[HMA-5117] Specify Icon Size if abnormal](https://github.com/hmrc/ios-components/pull/90)